### PR TITLE
Use Puppet data types instead of deprecated Stdlib functions

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,16 +1,10 @@
 class mcelog (
-  $ensure    = $::mcelog::params::ensure,
-  $packages  = $::mcelog::params::packages,
-  $settings  = $::mcelog::params::settings,
-  $config_fn = $::mcelog::params::config_fn,
-  $service   = $::mcelog::params::service
+  String $ensure                  = $::mcelog::params::ensure,
+  Array $packages                 = $::mcelog::params::packages,
+  Hash $settings                  = $::mcelog::params::settings,
+  Stdlib::Absolutepath $config_fn = $::mcelog::params::config_fn,
+  String $service                 = $::mcelog::params::service
 ) inherits mcelog::params {
-
-  validate_array($packages)
-  validate_hash($settings)
-  validate_absolute_path($config_fn)
-  validate_string($service, $ensure)
-
   contain ::mcelog::install
   contain ::mcelog::service
 


### PR DESCRIPTION
My PuppetServer is producing a lot of Warning due to usage of deprecated functions from Stdlib module. The usage of functions is not necessary when using build-in Puppet data types.
Puppet version: 6.12.0.
Example of warnings:
```
WARN  [puppetserver] Puppet This method is deprecated, please use the stdlib validate_legacy function,
                    with Stdlib::Compat::Absolute_Path. There is further documentation for validate_legacy function in the README.
```